### PR TITLE
[DO NOT REVIEW] Fix menu bar button bug

### DIFF
--- a/HackIllinois/Controllers/FlowControllers/HIMenuController.swift
+++ b/HackIllinois/Controllers/FlowControllers/HIMenuController.swift
@@ -170,7 +170,7 @@ extension HIMenuController {
             menuOverlap.constant = view.safeAreaInsets.top
 
         case .closed:
-            menuHeight.constant = 0
+            menuHeight.constant = view.safeAreaInsets.top
             menuOverlap.constant = 0
         }
     }

--- a/HackIllinois/Controllers/FlowControllers/HIMenuController.swift
+++ b/HackIllinois/Controllers/FlowControllers/HIMenuController.swift
@@ -167,7 +167,7 @@ extension HIMenuController {
         switch state {
         case .open:
             menuHeight.constant = menuItemsHeight.constant + 11 + 28 + view.safeAreaInsets.top
-            menuOverlap.constant = view.safeAreaInsets.top
+            menuOverlap.constant = 0
 
         case .closed:
             menuHeight.constant = view.safeAreaInsets.top


### PR DESCRIPTION
Fixes bug that caused hamburger menu button to clip into status bar when the menu was left open during backgrounding/foregrounding. 

Seems like it works. Tested by first reproducing then applying the fix and attempting to reproduce.
Fixes #149 