### PR TITLE
Check in scanner rename fix

### DIFF
--- a/HackIllinois/ViewControllers/HIEventDetailViewController.swift
+++ b/HackIllinois/ViewControllers/HIEventDetailViewController.swift
@@ -108,7 +108,7 @@ extension HIEventDetailViewController {
         guard let event = event else { return }
 
         // Check in is an event, identified by name
-        if event.name.caseInsensitiveCompare("Check In") == .orderedSame {
+        if event.name.caseInsensitiveCompare("Check-in") == .orderedSame {
             self.present(HIEventDetailViewController.checkInScannerViewController, animated: true)
         }
 


### PR DESCRIPTION
Event detail check in scanner renamed from "Check In" to "Check-in"