### PR TITLE
Auto scroll to top on tableview reload

### DIFF
--- a/HackIllinois/ViewControllers/HIBaseViewController.swift
+++ b/HackIllinois/ViewControllers/HIBaseViewController.swift
@@ -190,6 +190,9 @@ extension HIBaseViewController: NSFetchedResultsControllerDelegate {
                 animations: {
                     tableView.reloadData()
             })
+            if !tableView.visibleCells.isEmpty {
+                            tableView.scrollToRow(at: IndexPath(row: 0, section: 0), at: .top, animated: false)
+            }
         }
     }
 }

--- a/HackIllinois/ViewControllers/HIBaseViewController.swift
+++ b/HackIllinois/ViewControllers/HIBaseViewController.swift
@@ -190,9 +190,6 @@ extension HIBaseViewController: NSFetchedResultsControllerDelegate {
                 animations: {
                     tableView.reloadData()
             })
-            if !tableView.visibleCells.isEmpty {
-                            tableView.scrollToRow(at: IndexPath(row: 0, section: 0), at: .top, animated: false)
-            }
         }
     }
 }

--- a/HackIllinois/ViewControllers/HIHomeViewController.swift
+++ b/HackIllinois/ViewControllers/HIHomeViewController.swift
@@ -89,6 +89,9 @@ extension HIHomeViewController {
     func animateReload() {
         try? fetchedResultsController.performFetch()
         animateTableViewReload()
+        if let tableView = tableView, !tableView.visibleCells.isEmpty {
+            tableView.scrollToRow(at: IndexPath(row: 0, section: 0), at: .top, animated: false)
+        }
     }
 }
 

--- a/HackIllinois/ViewControllers/HIProjectViewController.swift
+++ b/HackIllinois/ViewControllers/HIProjectViewController.swift
@@ -111,6 +111,9 @@ extension HIProjectViewController {
     func animateReload() {
         try? fetchedResultsController.performFetch()
         animateTableViewReload()
+        if let tableView = tableView, !tableView.visibleCells.isEmpty {
+            tableView.scrollToRow(at: IndexPath(row: 0, section: 0), at: .top, animated: false)
+        }
     }
 }
 

--- a/HackIllinois/ViewControllers/HIScheduleViewController.swift
+++ b/HackIllinois/ViewControllers/HIScheduleViewController.swift
@@ -99,6 +99,9 @@ extension HIScheduleViewController {
     func animateReload() {
         try? fetchedResultsController.performFetch()
         animateTableViewReload()
+        if let tableView = tableView, !tableView.visibleCells.isEmpty {
+            tableView.scrollToRow(at: IndexPath(row: 0, section: 0), at: .top, animated: false)
+        }
     }
 }
 


### PR DESCRIPTION
- If the table is not empty, scroll to first index and section on reload
- Only called through the didSelectTab method, does not affect normal refreshing