### PR TITLE
Cleaned up attendee object with updated API

### DIFF
--- a/HIAPI/Models/Attendee.swift
+++ b/HIAPI/Models/Attendee.swift
@@ -22,17 +22,9 @@ public struct Attendee: Codable, APIReturnable {
     public let firstName: String?
     public let lastName: String?
     public let email: String
-    public let shirtSize: String
-    public let diet: DietaryRestrictions
-    public let age: Int
     public let graduationYear: Int
-    public let transportation: String
     public let school: String
     public let major: String
     public let gender: String
-    public let professionalInterest: [String]?
-    public let github: String
-    public let linkedin: String?
-    public let interests: [String]?
     public let phone: String
 }

--- a/HackIllinois/ViewControllers/HIUserDetailViewController.swift
+++ b/HackIllinois/ViewControllers/HIUserDetailViewController.swift
@@ -122,7 +122,6 @@ extension HIUserDetailViewController {
             }
         }
         userNameLabel.text = user.firstName.uppercased()
-        //userInfoLabel.text = user.attendee?.diet.description ?? "NO DIETARY RESTRICTIONS"
         setupPass()
     }
 }

--- a/HackIllinois/ViewControllers/HIUserDetailViewController.swift
+++ b/HackIllinois/ViewControllers/HIUserDetailViewController.swift
@@ -122,7 +122,7 @@ extension HIUserDetailViewController {
             }
         }
         userNameLabel.text = user.firstName.uppercased()
-        userInfoLabel.text = user.attendee?.diet.description ?? "NO DIETARY RESTRICTIONS"
+        //userInfoLabel.text = user.attendee?.diet.description ?? "NO DIETARY RESTRICTIONS"
         setupPass()
     }
 }


### PR DESCRIPTION
Originally getting this error sometimes, since shirtSize field does not exist anymore:
![Image from iOS(1)](https://user-images.githubusercontent.com/42848321/74904709-17450d80-5372-11ea-861a-02bdea254820.png)
