### PR TITLE
Bump out users who don't have respective attendee/staff role

### DIFF
--- a/HackIllinois/FlowControllers/HILoginFlowController.swift
+++ b/HackIllinois/FlowControllers/HILoginFlowController.swift
@@ -213,11 +213,21 @@ private extension HILoginFlowController {
                 let (apiRolesContainer, _) = try result.get()
                 var user = user
                 user.roles = apiRolesContainer.roles
-                if user.roles.contains(.applicant) {
+                if user.provider == .github && user.roles.contains(.attendee) {
                     self?.populateRegistrationData(buildingUser: user, sender: sender)
+                } else if user.provider == .google {
+                    if(user.roles.contains(.staff)) {
+                        DispatchQueue.main.async {
+                            NotificationCenter.default.post(name: .loginUser, object: nil, userInfo: ["user": user])
+                        }
+                    } else {
+                        DispatchQueue.main.async {
+                            sender.presentErrorController(title: "You must have a valid staff account to log in.", message: "", dismissParentOnCompletion: false)
+                        }
+                    }
                 } else {
                     DispatchQueue.main.async {
-                        NotificationCenter.default.post(name: .loginUser, object: nil, userInfo: ["user": user])
+                        sender.presentErrorController(title: "You must RSVP to log in.", message: "", dismissParentOnCompletion: false)
                     }
                 }
             } catch {

--- a/HackIllinois/FlowControllers/HILoginFlowController.swift
+++ b/HackIllinois/FlowControllers/HILoginFlowController.swift
@@ -216,7 +216,7 @@ private extension HILoginFlowController {
                 if user.provider == .github && user.roles.contains(.attendee) {
                     self?.populateRegistrationData(buildingUser: user, sender: sender)
                 } else if user.provider == .google {
-                    if(user.roles.contains(.staff)) {
+                    if user.roles.contains(.staff) {
                         DispatchQueue.main.async {
                             NotificationCenter.default.post(name: .loginUser, object: nil, userInfo: ["user": user])
                         }

--- a/HackIllinois/ViewControllers/HIProjectDetailViewController.swift
+++ b/HackIllinois/ViewControllers/HIProjectDetailViewController.swift
@@ -224,7 +224,7 @@ extension HIProjectDetailViewController {
         titleLabel.text = project.name
         descriptionLabel.text = project.info
         favoritedButton.isActive = project.favorite
-        mentorLabel.text = "Mentor(s): \(project.mentors.replacingOccurrences(of: ",", with: ", "))"
+        mentorLabel.text = project.mentors.replacingOccurrences(of: ",", with: ", ")
         numberLabel.text = "Table #\(project.number)"
         locationLabel.text = "Meeting Room: \(project.room)"
         populateTagLabels(stackView: tagStackView, tagsString: project.tags)


### PR DESCRIPTION
* Check roles of users during login, do not let them log in if they don't have respective attendee or staff role
* Also removed word "Mentor(s)" in project detail page