### PR TITLE
Set fixed timezone for schedule in iOS

### DIFF
--- a/HackIllinois/Misc/Formatters.swift
+++ b/HackIllinois/Misc/Formatters.swift
@@ -22,6 +22,7 @@ extension Formatter {
     static let simpleTime: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateFormat = "h:mm a"
+        formatter.timeZone = TimeZone(identifier: "America/Chicago")
         return formatter
     }()
 }


### PR DESCRIPTION
Fix timezone in Urbana local time for schedule and events time text.

Example incorrect time display when system in different timezone:
![Image from iOS](https://user-images.githubusercontent.com/725481/75232607-5d341400-576c-11ea-886a-7b086f65229b.png)