### PR TITLE
Fix Github Action Lint CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
   #   - name: Lint Test
   #     run: swiftlint lint --strict --config ./.swiftlint.yml
   lint:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
 
     steps:
         - uses: actions/checkout@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: Swift Lint and Build
 on:
   push:
     paths:
-      - '.github/workflows/swiftlint.yml'
+      - '.github/workflows/ci.yml'
       - '.swiftlint.yml'
       - '**/*.swift'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,27 +10,7 @@ on:
     branches: 
       - '**'
 
-
-
 jobs:
-  # TODO: Linting does not work still since it 
-  # doesn't seem to be using the .swiftlint.yml file
-  
-  # lint:
-
-  #   runs-on: macos-latest
-
-  #   steps:
-  #   - uses: actions/checkout@v2
-  #   - name: Lint
-  #     run: swiftlint 
-
-  #   - name: Display the path
-  #     run: ls -a
-  #     shell: bash
-
-  #   - name: Lint Test
-  #     run: swiftlint lint --strict --config ./.swiftlint.yml
   lint:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-        - uses: actions/checkout@v1
+        - uses: actions/checkout@v2
         - name: GitHub Action for SwiftLint (Only files changed in the PR)
           uses: norio-nomura/action-swiftlint@3.2.1
           env:

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -2,9 +2,15 @@ name: Swift Lint and Build
 
 on:
   push:
-    branches: [ dev, master ]
-  pull_request:
-    branches: [ dev, master ]
+    paths:
+      - '.github/workflows/swiftlint.yml'
+      - '.swiftlint.yml'
+      - '**/*.swift'
+
+    branches: 
+      - '**'
+
+
 
 jobs:
   # TODO: Linting does not work still since it 
@@ -25,6 +31,17 @@ jobs:
 
   #   - name: Lint Test
   #     run: swiftlint lint --strict --config ./.swiftlint.yml
+  lint:
+    runs-on: macos-latest
+
+    steps:
+        - uses: actions/checkout@v1
+        - name: GitHub Action for SwiftLint (Only files changed in the PR)
+          uses: norio-nomura/action-swiftlint@3.2.1
+          env:
+            DIFF_BASE: ${{ github.base_ref }}
+          with:
+            args: --strict
 
   build:
     runs-on: macos-latest

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,6 +1,7 @@
 disabled_rules:
   - cyclomatic_complexity
   - large_tuple
+  - comment_spacing
 
 opt_in_rules:
   - file_header

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: swift
-os: osx
-osx_image: xcode11.3
-
-script:
-  - swiftlint --strict
-  - xcodebuild clean build -project HackIllinois.xcodeproj -scheme HackIllinois -destination "platform=iOS Simulator,OS=13.3,name=iPhone 11" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ONLY_ACTIVE_ARCH=NO -quiet

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # iOS
-[![Build Status](https://travis-ci.com/HackIllinois/iOS.svg?branch=dev)](https://travis-ci.com/HackIllinois/iOS/tree/dev)  
+[![Build Status](https://github.com/hackillinois/api/workflows/CI/badge.svg)](https://github.com/HackIllinois/iOS/actions)  
 
 The repo hosts the official iOS app for HackIllinois. If you would like to get involved please reach out to the HackIllinois staff.
 


### PR DESCRIPTION
* comment_spacing rule added in 0.42 of swiftlint, added to ignored in swiftlint.yml
* changed github actions to every push since public repo builds are free, only private limited to 2k build minutes per month