### PR TITLE
Brought back EventDetailViewController, Limiting Event Description on the Schedule View

### DIFF
--- a/HackIllinois.xcodeproj/project.pbxproj
+++ b/HackIllinois.xcodeproj/project.pbxproj
@@ -727,11 +727,10 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 951827941EA35AF100049F79 /* Build configuration list for PBXNativeTarget "HackIllinois" */;
 			buildPhases = (
-				1C16D81827449A5B004E1C51 /* Run Swift Lint */,
 				9518277B1EA35AF100049F79 /* Sources */,
 				9518277C1EA35AF100049F79 /* Frameworks */,
 				9518277D1EA35AF100049F79 /* Resources */,
-				95CD0ED6201523B800D79DCC /* ShellScript */,
+				1C4BDBAA2744A032003BB3BB /* ShellScript */,
 				35D7CE9F20380ACF00654E28 /* Embed App Extensions */,
 				95E3143621FAD5B40092C22E /* Embed Frameworks */,
 			);
@@ -882,7 +881,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		1C16D81827449A5B004E1C51 /* Run Swift Lint */ = {
+		1C4BDBAA2744A032003BB3BB /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -891,27 +890,13 @@
 			);
 			inputPaths = (
 			);
-			name = "Run Swift Lint";
 			outputFileListPaths = (
 			);
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
-		};
-		95CD0ED6201523B800D79DCC /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+			shellScript = "if test -d \"/opt/homebrew/bin/\"; then\n  PATH=\"/opt/homebrew/bin/:${PATH}\"\nfi\n\nexport PATH\n\nif which swiftlint >/dev/null; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/HackIllinois.xcodeproj/project.pbxproj
+++ b/HackIllinois.xcodeproj/project.pbxproj
@@ -727,6 +727,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 951827941EA35AF100049F79 /* Build configuration list for PBXNativeTarget "HackIllinois" */;
 			buildPhases = (
+				1C16D81827449A5B004E1C51 /* Run Swift Lint */,
 				9518277B1EA35AF100049F79 /* Sources */,
 				9518277C1EA35AF100049F79 /* Frameworks */,
 				9518277D1EA35AF100049F79 /* Resources */,
@@ -881,6 +882,24 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		1C16D81827449A5B004E1C51 /* Run Swift Lint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Run Swift Lint";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
 		95CD0ED6201523B800D79DCC /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -892,7 +911,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi";
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/HackIllinois/UI/HILabel.swift
+++ b/HackIllinois/UI/HILabel.swift
@@ -117,7 +117,7 @@ class HILabel: UILabel {
             numberOfLines = 0
 
         case .detailText:
-            textHIColor = \.baseText
+            textHIColor = \.whiteText
             backgroundHIColor = \.clear
             font = HIAppearance.Font.detailText
             numberOfLines = 0
@@ -139,7 +139,7 @@ class HILabel: UILabel {
             font = HIAppearance.Font.contentSubtitle
 
         case .description:
-            textHIColor = \.baseText
+            textHIColor = \.whiteText
             backgroundHIColor = \.clear
             font = HIAppearance.Font.descriptionText
             numberOfLines = 0

--- a/HackIllinois/UI/HILabel.swift
+++ b/HackIllinois/UI/HILabel.swift
@@ -105,7 +105,7 @@ class HILabel: UILabel {
             font = HIAppearance.Font.sponsorText
 
         case .detailTitle:
-            textHIColor = \.baseText
+            textHIColor = \.whiteText
             backgroundHIColor = \.clear
             font = HIAppearance.Font.detailTitle
             numberOfLines = 0

--- a/HackIllinois/UI/TableView/Cells/HIBubbleCell/HIEventCell.swift
+++ b/HackIllinois/UI/TableView/Cells/HIBubbleCell/HIEventCell.swift
@@ -180,7 +180,7 @@ extension HIEventCell {
     
     // Returns the maximum number of characters allowed for the event description
     static func getMaxDescriptionTextLength() -> Int {
-        return 200
+        return 150
     }
 
     static func trimText(text: String, length: Int) -> String {

--- a/HackIllinois/UI/TableView/Cells/HIBubbleCell/HIEventCell.swift
+++ b/HackIllinois/UI/TableView/Cells/HIBubbleCell/HIEventCell.swift
@@ -26,7 +26,7 @@ class HIEventCell: HIBubbleCell {
         $0.activeImage = #imageLiteral(resourceName: "Favorited")
         $0.baseImage = #imageLiteral(resourceName: "Unfavorited")
     }
-
+    
     var contentStackView = UIStackView()
     var contentStackViewHeight = NSLayoutConstraint()
 
@@ -76,7 +76,7 @@ extension HIEventCell {
 // MARK: - Population
 extension HIEventCell {
     static func heightForCell(with event: Event, width: CGFloat) -> CGFloat {
-        let height = HILabel.heightForView(text: event.name, font: HIAppearance.Font.eventTitle, width: width - 98) + 90 + HILabel.heightForView(text: event.info, font: HIAppearance.Font.eventDetails, width: width - 100) + 15
+        let height = HILabel.heightForView(text: event.name, font: HIAppearance.Font.eventTitle, width: width - 98) + 90 + HILabel.heightForView(text: trimText(text: event.info, length: getMaxDescriptionTextLength()), font: HIAppearance.Font.eventDetails, width: width - 100) + 15
         if !event.sponsor.isEmpty {
             return height + 21
         }
@@ -105,8 +105,9 @@ extension HIEventCell {
         }
 
         let descriptionLabel = HILabel(style: .cellDescription)
-        descriptionLabel.text = rhs.info
-        let height = HILabel.heightForView(text: rhs.info, font: HIAppearance.Font.eventDetails, width: lhs.contentView.frame.width - 100)
+        let descriptionText = trimText(text: rhs.info, length: getMaxDescriptionTextLength())
+        descriptionLabel.text = descriptionText
+        let height = HILabel.heightForView(text: descriptionText, font: HIAppearance.Font.eventDetails, width: lhs.contentView.frame.width - 100)
         lhs.contentStackView.addArrangedSubview(descriptionLabel)
         lhs.contentStackView.setCustomSpacing(10, after: descriptionLabel)
 
@@ -171,5 +172,21 @@ extension HIEventCell {
         default:
             return \.eventTypePink
         }
+    }
+}
+
+// MARK: - Used for trimming the event description
+extension HIEventCell {
+    
+    static func getMaxDescriptionTextLength() -> Int {
+        return 150
+    }
+
+    static func trimText(text: String, length: Int) -> String {
+        if (text.count >= length) {
+            let index = text.index(text.startIndex, offsetBy: length)
+            return String(text[..<index]) + "..."
+        }
+        return text;
     }
 }

--- a/HackIllinois/UI/TableView/Cells/HIBubbleCell/HIEventCell.swift
+++ b/HackIllinois/UI/TableView/Cells/HIBubbleCell/HIEventCell.swift
@@ -178,15 +178,16 @@ extension HIEventCell {
 // MARK: - Used for trimming the event description
 extension HIEventCell {
     
+    // Returns the maximum number of characters allowed for the event description
     static func getMaxDescriptionTextLength() -> Int {
-        return 150
+        return 200
     }
 
     static func trimText(text: String, length: Int) -> String {
-        if (text.count >= length) {
+        if text.count >= length {
             let index = text.index(text.startIndex, offsetBy: length)
             return String(text[..<index]) + "..."
         }
-        return text;
+        return text
     }
 }

--- a/HackIllinois/UI/TableView/Cells/HIEventDetailLocationCell.swift
+++ b/HackIllinois/UI/TableView/Cells/HIEventDetailLocationCell.swift
@@ -23,7 +23,7 @@ class HIEventDetailLocationCell: UITableViewCell {
     let mapView = MKMapView()
     let mapAnnotation = MKPointAnnotation()
     let titleLabel = HILabel(style: .location) {
-        $0.textColor <- \.baseText
+        $0.textColor <- \.whiteText
         $0.font = HIAppearance.Font.contentSubtitle
         $0.translatesAutoresizingMaskIntoConstraints = false
     }

--- a/HackIllinois/ViewControllers/HIEventDetailViewController.swift
+++ b/HackIllinois/ViewControllers/HIEventDetailViewController.swift
@@ -180,10 +180,6 @@ extension HIEventDetailViewController {
         favoritedButton.isActive = event.favorite
 
         tableView?.reloadData()
-        /* Caused table view error, no need to scroll to top row */
-        
-//        let indexPath = IndexPath(row: 0, section: 0)
-//        tableView?.scrollToRow(at: indexPath, at: .top, animated: true)
         view.layoutIfNeeded()
         let targetSize = CGSize(width: descriptionLabel.frame.width, height: .greatestFiniteMagnitude)
         let neededSize = descriptionLabel.sizeThatFits(targetSize)

--- a/HackIllinois/ViewControllers/HIEventDetailViewController.swift
+++ b/HackIllinois/ViewControllers/HIEventDetailViewController.swift
@@ -18,8 +18,6 @@ import APIManager
 
 class HIEventDetailViewController: HIBaseViewController {
     // MARK: - Properties
-    private static let scannerViewController = HIEventScannerViewController()
-    private static let checkInScannerViewController = HICheckInScannerViewController()
     var event: Event?
 
     // MARK: Views
@@ -109,43 +107,6 @@ extension HIEventDetailViewController {
         .launch()
     }
 
-//    @objc func didSelectScanner(_ sender: UIButton) {
-//        guard let event = event else { return }
-//
-//        // Check in is an event, identified by name
-//        if event.name.caseInsensitiveCompare("Check-in") == .orderedSame {
-//            self.present(HIEventDetailViewController.checkInScannerViewController, animated: true)
-//        }
-//
-//        let now = Date()
-//        if event.startTime.addingTimeInterval(-15*60) > now || now > event.endTime {
-//            let alertController = UIAlertController(title: "Are you sure?", message: "You are outside the scanning period for the event", preferredStyle: .alert)
-//            alertController.addAction(UIAlertAction(title: "Cancel", style: .default, handler: nil))
-//            alertController.addAction(UIAlertAction(title: "Yes", style: .default, handler: { _ in
-//                HIEventDetailViewController.scannerViewController.event = event
-//                self.present(HIEventDetailViewController.scannerViewController, animated: true)
-//            }))
-//            self.present(alertController, animated: true, completion: nil)
-//        } else {
-//            HIEventDetailViewController.scannerViewController.event = event
-//            self.present(HIEventDetailViewController.scannerViewController, animated: true)
-//        }
-//    }
-//
-//    @objc func didSelectScanButton(_ sender: UIBarButtonItem) {
-//        guard let event = event else { return }
-//        let now = Date()
-//        if event.startTime.addingTimeInterval(-15*60) > now {
-//            let message = "The scanning period for this event has not begun; scanning begins 15 minutes before the event."
-//            presentErrorController(title: "Sorry", message: message, dismissParentOnCompletion: false)
-//        } else if now > event.endTime {
-//            presentErrorController(title: "Sorry", message: "The scanning period for this event has ended.", dismissParentOnCompletion: false)
-//        } else {
-//            HIEventDetailViewController.scannerViewController.event = event
-//            navigationController?.pushViewController(HIEventDetailViewController.scannerViewController, animated: true)
-//        }
-//    }
-
     @objc func didSelectCloseButton(_ sender: HIButton) {
         self.dismiss(animated: true, completion: nil)
     }
@@ -174,8 +135,6 @@ extension HIEventDetailViewController {
         upperContainerView.addSubview(sponsorLabel)
         sponsorLabel.leadingAnchor.constraint(equalTo: titleLabel.leadingAnchor).isActive = true
         sponsorLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 5).isActive = true
-
-//        setupScannerIfApplicable()
 
         if !HIApplicationStateController.shared.isGuest {
             setupFavoritedButton()
@@ -247,17 +206,6 @@ extension HIEventDetailViewController {
         closeButton.constrain(height: 20)
     }
 
-//    func setupScannerIfApplicable() {
-//        if let user = HIApplicationStateController.shared.user, !user.roles.intersection([.staff, .admin]).isEmpty {
-//            view.addSubview(cameraButton)
-//            cameraButton.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 10).isActive = true
-//            cameraButton.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -12).isActive = true
-//            cameraButton.heightAnchor.constraint(equalToConstant: 30).isActive = true
-//            cameraButton.widthAnchor.constraint(equalToConstant: 30).isActive = true
-//            cameraButton.addTarget(self, action: #selector(didSelectScanner(_:)), for: .touchUpInside)
-//        }
-//    }
-
     func setupFavoritedButton() {
         favoritedButton.addTarget(self, action: #selector(didSelectFavoriteButton(_:)), for: .touchUpInside)
         upperContainerView.addSubview(favoritedButton)
@@ -274,9 +222,6 @@ extension HIEventDetailViewController {
     @objc dynamic override func setupNavigationItem() {
         super.setupNavigationItem()
         title = "EVENT DETAILS"
-//        if let user = HIApplicationStateController.shared.user, !user.roles.intersection([.staff, .admin]).isEmpty {
-//            navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .camera, target: self, action: #selector(didSelectScanButton(_:)))
-//        }
     }
 }
 

--- a/HackIllinois/ViewControllers/HIEventDetailViewController.swift
+++ b/HackIllinois/ViewControllers/HIEventDetailViewController.swift
@@ -130,12 +130,14 @@ extension HIEventDetailViewController {
 
         upperContainerView.addSubview(titleLabel)
         titleLabel.leadingAnchor.constraint(equalTo: closeButton.leadingAnchor).isActive = true
+        titleLabel.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -12).isActive = true
         titleLabel.topAnchor.constraint(equalTo: upperContainerView.topAnchor).isActive = true
-
+        
         upperContainerView.addSubview(sponsorLabel)
         sponsorLabel.leadingAnchor.constraint(equalTo: titleLabel.leadingAnchor).isActive = true
         sponsorLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 5).isActive = true
-
+        
+        // Only attendees can favorite events
         if !HIApplicationStateController.shared.isGuest {
             setupFavoritedButton()
         }
@@ -168,6 +170,7 @@ extension HIEventDetailViewController {
         super.viewWillAppear(animated)
         guard let event = event else { return }
         titleLabel.text = event.name;
+        
         if !event.sponsor.isEmpty {
             sponsorLabel.text = "Sponsored by \(event.sponsor)"
         } else {
@@ -201,14 +204,12 @@ extension HIEventDetailViewController {
     }
 
     func setupFavoritedButton() {
-        if let user = HIApplicationStateController.shared.user, !user.roles.isDisjoint(with: [.attendee]) {
-            view.addSubview(favoritedButton)
-            favoritedButton.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 10).isActive = true
-            favoritedButton.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -12).isActive = true
-            favoritedButton.heightAnchor.constraint(equalToConstant: 30).isActive = true
-            favoritedButton.widthAnchor.constraint(equalToConstant: 30).isActive = true
-            favoritedButton.addTarget(self, action: #selector(didSelectFavoriteButton(_:)), for: .touchUpInside)
-        }
+        view.addSubview(favoritedButton)
+        favoritedButton.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 10).isActive = true
+        favoritedButton.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -12).isActive = true
+        favoritedButton.heightAnchor.constraint(equalToConstant: 30).isActive = true
+        favoritedButton.widthAnchor.constraint(equalToConstant: 30).isActive = true
+        favoritedButton.addTarget(self, action: #selector(didSelectFavoriteButton(_:)), for: .touchUpInside)
     }
 }
 

--- a/HackIllinois/ViewControllers/HIEventDetailViewController.swift
+++ b/HackIllinois/ViewControllers/HIEventDetailViewController.swift
@@ -35,7 +35,7 @@ class HIEventDetailViewController: HIBaseViewController {
     }
     private let titleLabel = HILabel(style: .detailTitle) {
         $0.translatesAutoresizingMaskIntoConstraints = false
-        $0.textColor <- \.baseText
+        $0.textColor <- \.whiteText
         $0.font = HIAppearance.Font.detailTitle
     }
 
@@ -47,29 +47,29 @@ class HIEventDetailViewController: HIBaseViewController {
 
     private let timeLabel = HILabel(style: .description) {
         $0.translatesAutoresizingMaskIntoConstraints = false
-        $0.textColor <- \.baseText
+        $0.textColor <- \.whiteText
         $0.font = HIAppearance.Font.contentText
     }
 
     private let descriptionLabel = HILabel(style: .detailText) {
         $0.translatesAutoresizingMaskIntoConstraints = false
-        $0.textColor <- \.baseText
+        $0.textColor <- \.whiteText
         $0.numberOfLines = 0
     }
     private let favoritedButton = HIButton {
-        $0.tintHIColor = \.baseText
+        $0.tintHIColor = \.whiteText
         $0.backgroundHIColor = \.clear
         $0.activeImage = #imageLiteral(resourceName: "Favorited")
         $0.baseImage = #imageLiteral(resourceName: "Unfavorited")
     }
     private let closeButton = HIButton {
-        $0.tintHIColor = \.baseText
+        $0.tintHIColor = \.whiteText
         $0.backgroundHIColor = \.clear
         $0.activeImage = #imageLiteral(resourceName: "MenuClose")
         $0.baseImage = #imageLiteral(resourceName: "MenuClose")
     }
     private let cameraButton = HIButton {
-        $0.tintHIColor = \.baseText
+        $0.tintHIColor = \.whiteText
         $0.backgroundHIColor = \.clear
         $0.activeImage = #imageLiteral(resourceName: "Camera")
         $0.baseImage = #imageLiteral(resourceName: "Camera")
@@ -208,7 +208,9 @@ extension HIEventDetailViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         guard let event = event else { return }
-        titleLabel.text = event.name
+        
+        titleLabel.text = event.name;
+                        
         if !event.sponsor.isEmpty {
             sponsorLabel.text = "Sponsored by \(event.sponsor)"
         } else {
@@ -219,8 +221,10 @@ extension HIEventDetailViewController {
         favoritedButton.isActive = event.favorite
 
         tableView?.reloadData()
-        let indexPath = IndexPath(row: 0, section: 0)
-        tableView?.scrollToRow(at: indexPath, at: .top, animated: true)
+        /* Caused table view error, no need to scroll to top row */
+        
+//        let indexPath = IndexPath(row: 0, section: 0)
+//        tableView?.scrollToRow(at: indexPath, at: .top, animated: true)
         view.layoutIfNeeded()
         let targetSize = CGSize(width: descriptionLabel.frame.width, height: .greatestFiniteMagnitude)
         let neededSize = descriptionLabel.sizeThatFits(targetSize)

--- a/HackIllinois/ViewControllers/HIEventDetailViewController.swift
+++ b/HackIllinois/ViewControllers/HIEventDetailViewController.swift
@@ -203,17 +203,9 @@ extension HIEventDetailViewController {
     }
 
     func setupFavoritedButton() {
-        print("setting uo")
-        if let user = HIApplicationStateController.shared.user, !user.roles.intersection([.attendee]).isEmpty {
-            print("we in")
+        if let user = HIApplicationStateController.shared.user, !user.roles.isDisjoint(with: [.attendee]) {
             view.addSubview(favoritedButton)
-//            favoritedButton.topAnchor.constraint(equalTo: titleLabel.topAnchor).isActive = true
-//            favoritedButton.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -12).isActive = true
-//            favoritedButton.heightAnchor.constraint(equalToConstant: 30).isActive = true
-//            favoritedButton.widthAnchor.constraint(equalToConstant: 30).isActive = true
-            
             favoritedButton.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 10).isActive = true
-//            favoritedButton.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor).isActive = true
             favoritedButton.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -12).isActive = true
             favoritedButton.heightAnchor.constraint(equalToConstant: 30).isActive = true
             favoritedButton.widthAnchor.constraint(equalToConstant: 30).isActive = true

--- a/HackIllinois/ViewControllers/HIEventDetailViewController.swift
+++ b/HackIllinois/ViewControllers/HIEventDetailViewController.swift
@@ -109,42 +109,42 @@ extension HIEventDetailViewController {
         .launch()
     }
 
-    @objc func didSelectScanner(_ sender: UIButton) {
-        guard let event = event else { return }
-
-        // Check in is an event, identified by name
-        if event.name.caseInsensitiveCompare("Check-in") == .orderedSame {
-            self.present(HIEventDetailViewController.checkInScannerViewController, animated: true)
-        }
-
-        let now = Date()
-        if event.startTime.addingTimeInterval(-15*60) > now || now > event.endTime {
-            let alertController = UIAlertController(title: "Are you sure?", message: "You are outside the scanning period for the event", preferredStyle: .alert)
-            alertController.addAction(UIAlertAction(title: "Cancel", style: .default, handler: nil))
-            alertController.addAction(UIAlertAction(title: "Yes", style: .default, handler: { _ in
-                HIEventDetailViewController.scannerViewController.event = event
-                self.present(HIEventDetailViewController.scannerViewController, animated: true)
-            }))
-            self.present(alertController, animated: true, completion: nil)
-        } else {
-            HIEventDetailViewController.scannerViewController.event = event
-            self.present(HIEventDetailViewController.scannerViewController, animated: true)
-        }
-    }
-
-    @objc func didSelectScanButton(_ sender: UIBarButtonItem) {
-        guard let event = event else { return }
-        let now = Date()
-        if event.startTime.addingTimeInterval(-15*60) > now {
-            let message = "The scanning period for this event has not begun; scanning begins 15 minutes before the event."
-            presentErrorController(title: "Sorry", message: message, dismissParentOnCompletion: false)
-        } else if now > event.endTime {
-            presentErrorController(title: "Sorry", message: "The scanning period for this event has ended.", dismissParentOnCompletion: false)
-        } else {
-            HIEventDetailViewController.scannerViewController.event = event
-            navigationController?.pushViewController(HIEventDetailViewController.scannerViewController, animated: true)
-        }
-    }
+//    @objc func didSelectScanner(_ sender: UIButton) {
+//        guard let event = event else { return }
+//
+//        // Check in is an event, identified by name
+//        if event.name.caseInsensitiveCompare("Check-in") == .orderedSame {
+//            self.present(HIEventDetailViewController.checkInScannerViewController, animated: true)
+//        }
+//
+//        let now = Date()
+//        if event.startTime.addingTimeInterval(-15*60) > now || now > event.endTime {
+//            let alertController = UIAlertController(title: "Are you sure?", message: "You are outside the scanning period for the event", preferredStyle: .alert)
+//            alertController.addAction(UIAlertAction(title: "Cancel", style: .default, handler: nil))
+//            alertController.addAction(UIAlertAction(title: "Yes", style: .default, handler: { _ in
+//                HIEventDetailViewController.scannerViewController.event = event
+//                self.present(HIEventDetailViewController.scannerViewController, animated: true)
+//            }))
+//            self.present(alertController, animated: true, completion: nil)
+//        } else {
+//            HIEventDetailViewController.scannerViewController.event = event
+//            self.present(HIEventDetailViewController.scannerViewController, animated: true)
+//        }
+//    }
+//
+//    @objc func didSelectScanButton(_ sender: UIBarButtonItem) {
+//        guard let event = event else { return }
+//        let now = Date()
+//        if event.startTime.addingTimeInterval(-15*60) > now {
+//            let message = "The scanning period for this event has not begun; scanning begins 15 minutes before the event."
+//            presentErrorController(title: "Sorry", message: message, dismissParentOnCompletion: false)
+//        } else if now > event.endTime {
+//            presentErrorController(title: "Sorry", message: "The scanning period for this event has ended.", dismissParentOnCompletion: false)
+//        } else {
+//            HIEventDetailViewController.scannerViewController.event = event
+//            navigationController?.pushViewController(HIEventDetailViewController.scannerViewController, animated: true)
+//        }
+//    }
 
     @objc func didSelectCloseButton(_ sender: HIButton) {
         self.dismiss(animated: true, completion: nil)
@@ -175,7 +175,7 @@ extension HIEventDetailViewController {
         sponsorLabel.leadingAnchor.constraint(equalTo: titleLabel.leadingAnchor).isActive = true
         sponsorLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 5).isActive = true
 
-        setupScannerIfApplicable()
+//        setupScannerIfApplicable()
 
         if !HIApplicationStateController.shared.isGuest {
             setupFavoritedButton()
@@ -247,16 +247,16 @@ extension HIEventDetailViewController {
         closeButton.constrain(height: 20)
     }
 
-    func setupScannerIfApplicable() {
-        if let user = HIApplicationStateController.shared.user, !user.roles.intersection([.staff, .admin]).isEmpty {
-            view.addSubview(cameraButton)
-            cameraButton.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 10).isActive = true
-            cameraButton.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -12).isActive = true
-            cameraButton.heightAnchor.constraint(equalToConstant: 30).isActive = true
-            cameraButton.widthAnchor.constraint(equalToConstant: 30).isActive = true
-            cameraButton.addTarget(self, action: #selector(didSelectScanner(_:)), for: .touchUpInside)
-        }
-    }
+//    func setupScannerIfApplicable() {
+//        if let user = HIApplicationStateController.shared.user, !user.roles.intersection([.staff, .admin]).isEmpty {
+//            view.addSubview(cameraButton)
+//            cameraButton.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 10).isActive = true
+//            cameraButton.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -12).isActive = true
+//            cameraButton.heightAnchor.constraint(equalToConstant: 30).isActive = true
+//            cameraButton.widthAnchor.constraint(equalToConstant: 30).isActive = true
+//            cameraButton.addTarget(self, action: #selector(didSelectScanner(_:)), for: .touchUpInside)
+//        }
+//    }
 
     func setupFavoritedButton() {
         favoritedButton.addTarget(self, action: #selector(didSelectFavoriteButton(_:)), for: .touchUpInside)
@@ -274,9 +274,9 @@ extension HIEventDetailViewController {
     @objc dynamic override func setupNavigationItem() {
         super.setupNavigationItem()
         title = "EVENT DETAILS"
-        if let user = HIApplicationStateController.shared.user, !user.roles.intersection([.staff, .admin]).isEmpty {
-            navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .camera, target: self, action: #selector(didSelectScanButton(_:)))
-        }
+//        if let user = HIApplicationStateController.shared.user, !user.roles.intersection([.staff, .admin]).isEmpty {
+//            navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .camera, target: self, action: #selector(didSelectScanButton(_:)))
+//        }
     }
 }
 

--- a/HackIllinois/ViewControllers/HIEventDetailViewController.swift
+++ b/HackIllinois/ViewControllers/HIEventDetailViewController.swift
@@ -167,9 +167,7 @@ extension HIEventDetailViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         guard let event = event else { return }
-        
         titleLabel.text = event.name;
-                        
         if !event.sponsor.isEmpty {
             sponsorLabel.text = "Sponsored by \(event.sponsor)"
         } else {

--- a/HackIllinois/ViewControllers/HIEventDetailViewController.swift
+++ b/HackIllinois/ViewControllers/HIEventDetailViewController.swift
@@ -203,13 +203,22 @@ extension HIEventDetailViewController {
     }
 
     func setupFavoritedButton() {
-        favoritedButton.addTarget(self, action: #selector(didSelectFavoriteButton(_:)), for: .touchUpInside)
-        upperContainerView.addSubview(favoritedButton)
-        favoritedButton.topAnchor.constraint(equalTo: titleLabel.topAnchor).isActive = true
-        favoritedButton.leadingAnchor.constraint(equalTo: titleLabel.trailingAnchor).isActive = true
-        favoritedButton.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -12).isActive = true
-        favoritedButton.heightAnchor.constraint(equalToConstant: 30).isActive = true
-        favoritedButton.widthAnchor.constraint(equalToConstant: 30).isActive = true
+        print("setting uo")
+        if let user = HIApplicationStateController.shared.user, !user.roles.intersection([.attendee]).isEmpty {
+            print("we in")
+            view.addSubview(favoritedButton)
+//            favoritedButton.topAnchor.constraint(equalTo: titleLabel.topAnchor).isActive = true
+//            favoritedButton.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -12).isActive = true
+//            favoritedButton.heightAnchor.constraint(equalToConstant: 30).isActive = true
+//            favoritedButton.widthAnchor.constraint(equalToConstant: 30).isActive = true
+            
+            favoritedButton.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 10).isActive = true
+//            favoritedButton.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor).isActive = true
+            favoritedButton.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -12).isActive = true
+            favoritedButton.heightAnchor.constraint(equalToConstant: 30).isActive = true
+            favoritedButton.widthAnchor.constraint(equalToConstant: 30).isActive = true
+            favoritedButton.addTarget(self, action: #selector(didSelectFavoriteButton(_:)), for: .touchUpInside)
+        }
     }
 }
 

--- a/HackIllinois/ViewControllers/HIEventListViewController.swift
+++ b/HackIllinois/ViewControllers/HIEventListViewController.swift
@@ -16,8 +16,7 @@ import HIAPI
 import APIManager
 
 class HIEventListViewController: HIBaseViewController {
-    // Event detail view controller will not be presented for HackIllinois 2021
-    // let eventDetailViewController = HIEventDetailViewController()
+    let eventDetailViewController = HIEventDetailViewController()
 }
 
 // MARK: - UITableView Setup
@@ -26,8 +25,7 @@ extension HIEventListViewController {
         if let tableView = tableView {
             tableView.register(HIDateHeader.self, forHeaderFooterViewReuseIdentifier: HIDateHeader.identifier)
             tableView.register(HIEventCell.self, forCellReuseIdentifier: HIEventCell.identifier)
-            tableView.allowsSelection = false
-            // registerForPreviewing(with: self, sourceView: tableView)
+            registerForPreviewing(with: self, sourceView: tableView)
         }
         super.setupTableView()
     }
@@ -56,8 +54,8 @@ extension HIEventListViewController {
     }
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-//        eventDetailViewController.event = _fetchedResultsController?.object(at: indexPath) as? Event
-//        self.present(eventDetailViewController, animated: true, completion: nil)
+        eventDetailViewController.event = _fetchedResultsController?.object(at: indexPath) as? Event
+        self.present(eventDetailViewController, animated: true, completion: nil)
         super.tableView(tableView, didSelectRowAt: indexPath)
     }
 }
@@ -67,7 +65,6 @@ extension HIEventListViewController {
     override func refresh(_ sender: UIRefreshControl) {
         super.refresh(sender)
         HIEventDataSource.refresh(completion: endRefreshing)
-        tableView?.reloadData()
     }
 }
 
@@ -102,19 +99,19 @@ extension HIEventListViewController: HIEventCellDelegate {
 }
 
 // MARK: - UIViewControllerPreviewingDelegate
-//extension HIEventListViewController: UIViewControllerPreviewingDelegate {
-//    func previewingContext(_ previewingContext: UIViewControllerPreviewing, viewControllerForLocation location: CGPoint) -> UIViewController? {
-//        guard let tableView = tableView,
-//            let indexPath = tableView.indexPathForRow(at: location),
-//            let event = _fetchedResultsController?.object(at: indexPath) as? Event else {
-//                return nil
-//        }
-//        previewingContext.sourceRect = tableView.rectForRow(at: indexPath)
-//        eventDetailViewController.event = event
-//        return eventDetailViewController
-//    }
-//
-//    func previewingContext(_ previewingContext: UIViewControllerPreviewing, commit viewControllerToCommit: UIViewController) {
-//        self.present(viewControllerToCommit, animated: true, completion: nil)
-//    }
-//}
+extension HIEventListViewController: UIViewControllerPreviewingDelegate {
+    func previewingContext(_ previewingContext: UIViewControllerPreviewing, viewControllerForLocation location: CGPoint) -> UIViewController? {
+        guard let tableView = tableView,
+            let indexPath = tableView.indexPathForRow(at: location),
+            let event = _fetchedResultsController?.object(at: indexPath) as? Event else {
+                return nil
+        }
+        previewingContext.sourceRect = tableView.rectForRow(at: indexPath)
+        eventDetailViewController.event = event
+        return eventDetailViewController
+    }
+
+    func previewingContext(_ previewingContext: UIViewControllerPreviewing, commit viewControllerToCommit: UIViewController) {
+        self.present(viewControllerToCommit, animated: true, completion: nil)
+    }
+}


### PR DESCRIPTION
## Description

- Brought back EventDetailViewController. Now, click on a view show's a popup view with more information.
- The size of the description for each event on the schedule page is limited. This is to prevent the user from scrolling too much on that page. Also, each EventCell is now roughly the same size.

<!--
A few bullet points describing the overall goals of the pull request's commits.
-->

## Todos

- [x] Fix issue with favoriting throwing 403 error
- [x] Debug event location
- [x] Figure out if anything needs to fill up EventDetailViewController

<!--
- [ ] Tests
- [ ] More Tests
- [ ] Documentation
-->

## Screenshots

![Simulator Screen Shot - iPhone 11 - 2021-11-16 at 20 59 13](https://user-images.githubusercontent.com/21179174/142129249-83367423-d25f-4a82-93d2-5b6aef590e07.png)

![Simulator Screen Shot - iPhone 11 - 2021-11-16 at 21 26 19](https://user-images.githubusercontent.com/21179174/142129266-4e7a7cad-a230-48ec-bf5f-fa0a59c0dce0.png)

<!--
Mac OS Screenshots: ctrl + shift + cmd + 3 (entire screen) or 4 (selection of screen), then paste in editor
Mac OS GIFs: Try using Kap
Linux/Windows: Ctrl + Alt + PrintScreen (of a window) or Ctrl + Shift + PrintScreen (selection of screen), then paste in editor
-->
