### PR TITLE
Updated profile error page

### DIFF
--- a/HackIllinois/UI/HIErrorView.swift
+++ b/HackIllinois/UI/HIErrorView.swift
@@ -60,11 +60,11 @@ class HIErrorView: HIView {
         errorLabel.leadingAnchor.constraint(equalTo: leadingAnchor).isActive = true
         errorLabel.centerXAnchor.constraint(equalTo: centerXAnchor).isActive = true
 
-        self.addSubview(logoutButton)
+        /*self.addSubview(logoutButton)
         logoutButton.topAnchor.constraint(equalTo: errorLabel.bottomAnchor, constant: 10).isActive = true
         logoutButton.centerXAnchor.constraint(equalTo: centerXAnchor).isActive = true
         logoutButton.widthAnchor.constraint(equalTo: widthAnchor, multiplier: 0.5).isActive = true
-        logoutButton.heightAnchor.constraint(equalToConstant: 40).isActive = true
+        logoutButton.heightAnchor.constraint(equalToConstant: 40).isActive = true*/
 
         translatesAutoresizingMaskIntoConstraints = false
         NotificationCenter.default.addObserver(self, selector: #selector(refreshForThemeChange), name: .themeDidChange, object: nil)

--- a/HackIllinois/UI/HILabel.swift
+++ b/HackIllinois/UI/HILabel.swift
@@ -260,14 +260,14 @@ class HILabel: UILabel {
             textAlignment = .center
 
         case .error:
-            textHIColor = \.baseText
+            textHIColor = \.white
             backgroundHIColor = \.clear
             font = HIAppearance.Font.detailSubtitle
             textAlignment = .center
             numberOfLines = 0
 
         case .codeError:
-            textHIColor = \.baseText
+            textHIColor = \.white
             backgroundHIColor = \.clear
             font = HIAppearance.Font.detailSubtitle
             textAlignment = .center


### PR DESCRIPTION

## Description

Removed logout button from view because it kept crashing the app. Changed the error message color to white to make the label more readable.

<!--
A few bullet points describing the overall goals of the pull request's commits.
-->

## Todos

<!--
- [ ] Tests
- [ ] More Tests
- [ ] Documentation
-->
<img width="326" alt="Screen Shot 2023-02-10 at 5 06 30 PM" src="https://user-images.githubusercontent.com/91706701/218219180-34c6b0f9-cc8b-4011-b071-1fcf7a20152e.png">


## Screenshots

<!--
Mac OS Screenshots: ctrl + shift + cmd + 3 (entire screen) or 4 (selection of screen), then paste in editor
Mac OS GIFs: Try using Kap
Linux/Windows: Ctrl + Alt + PrintScreen (of a window) or Ctrl + Shift + PrintScreen (selection of screen), then paste in editor
-->
