### PR TITLE
Updated constraints on event cell

### DIFF
--- a/HackIllinois/UI/HIAppearance.swift
+++ b/HackIllinois/UI/HIAppearance.swift
@@ -73,7 +73,6 @@ struct HIAppearance: Equatable {
     let profileCardOther: UIColor
     let profileCardNone: UIColor
 
-
     let profileBaseText: UIColor
 
     let clear: UIColor = .clear

--- a/HackIllinois/UI/TableView/Cells/HIBubbleCell/HIEventCell.swift
+++ b/HackIllinois/UI/TableView/Cells/HIBubbleCell/HIEventCell.swift
@@ -98,7 +98,10 @@ extension HIEventCell {
             return height + (20 * heightConstant)
         }
         if UIDevice.current.userInterfaceIdiom == .pad {
-            return height + (22 * (heightConstant / 1.45))
+            return height + (22 * (heightConstant / 1.40))
+        }
+        if event.info.count <= 40 {
+            return height - 15
         }
         return height + 5
     }
@@ -114,6 +117,7 @@ extension HIEventCell {
         let titleLabel = HILabel(style: .event)
         titleLabel.numberOfLines = 2
         lhs.headerView.addArrangedSubview(titleLabel)
+        
         titleLabel.text = rhs.name
         lhs.headerView.setCustomSpacing(9, after: titleLabel)
         if UIDevice.current.userInterfaceIdiom == .pad {
@@ -125,7 +129,7 @@ extension HIEventCell {
             sponsorImageView = UIImageView(image: #imageLiteral(resourceName: "SponsorPad"))
             lhs.headerView.setCustomSpacing(18, after: titleLabel)
         }
-        titleLabel.constrain(width: lhs.contentView.frame.width - 120, height: (HILabel.heightForView(text: rhs.name, font: HIAppearance.Font.eventTitle!, width: lhs.contentView.frame.width - 137)) * bubbleConstant)
+        titleLabel.constrain(width: lhs.contentView.frame.width - 100, height: (HILabel.heightForView(text: rhs.name, font: HIAppearance.Font.eventTitle!, width: lhs.contentView.frame.width - 137)) * bubbleConstant)
         let upperContainerView = HIView {
             lhs.contentStackView.addArrangedSubview($0)
             $0.translatesAutoresizingMaskIntoConstraints = false


### PR DESCRIPTION
## Description

Fixed event cell spacing when the description is only one line. Made the event title mostly fit on one line.

## Todos

Tweak iPad constraints so when the description is only one line long, extra spacing does not appear.

## Screenshots

<!--
Mac OS Screenshots: ctrl + shift + cmd + 3 (entire screen) or 4 (selection of screen), then paste in editor
Mac OS GIFs: Try using Kap
Linux/Windows: Ctrl + Alt + PrintScreen (of a window) or Ctrl + Shift + PrintScreen (selection of screen), then paste in editor
-->
<img width="302" alt="Screen Shot 2023-02-15 at 9 39 06 PM" src="https://user-images.githubusercontent.com/91706701/219262453-7a69ca41-ad4d-4097-a97a-b664397c92ad.png">
