### PR TITLE
Fixed height constraint of leaderboard name

### DIFF
--- a/HackIllinois/UI/TableView/Cells/HILeaderboardCell.swift
+++ b/HackIllinois/UI/TableView/Cells/HILeaderboardCell.swift
@@ -79,8 +79,9 @@ extension HILeaderboardCell {
         lhs.nameLabel.leadingAnchor.constraint(equalTo: lhs.rankLabel.leadingAnchor, constant: 50 * padConstant).isActive = true
         
         if UIDevice.current.userInterfaceIdiom == .pad {
+            lhs.nameLabel.constrain(width: lhs.contentView.frame.width, height: 40.0)
         } else {
-            lhs.nameLabel.constrain(width: lhs.contentView.frame.width - 185, height: (HILabel.heightForView(text: discord, font: HIAppearance.Font.leaderboardPoints!, width: lhs.contentView.frame.width - 185)))
+            lhs.nameLabel.constrain(width: lhs.contentView.frame.width - 185, height: 20.0)
             lhs.nameLabel.numberOfLines = 1
         }
     }

--- a/HackIllinois/ViewControllers/HILeaderboardListViewController.swift
+++ b/HackIllinois/ViewControllers/HILeaderboardListViewController.swift
@@ -39,7 +39,7 @@ extension HILeaderboardListViewController {
             cell.backgroundColor = #colorLiteral(red: 0.7882352941, green: 0.8235294118, blue: 0.8980392157, alpha: 1)
             tableView.separatorStyle = .singleLine
             tableView.separatorInset = UIEdgeInsets()
-            tableView.separatorColor = UIColor.black
+            tableView.separatorColor = #colorLiteral(red: 0.04009541315, green: 0.1307413591, blue: 0.3802352191, alpha: 1)
             // Round certain corners based on row
             if indexPath.row == 0 {
                 cell.layer.cornerRadius = 20


### PR DESCRIPTION
## Description

Fixed issue where the bottom of certain letters such as 'y' get cut off.

<!--
A few bullet points describing the overall goals of the pull request's commits.
-->

## Todos
Try to remove the separator lines at the top most and bottom most cells.
<!--
- [ ] Tests
- [ ] More Tests
- [ ] Documentation
-->

## Screenshots
<img width="294" alt="Screen Shot 2023-02-22 at 9 19 29 PM" src="https://user-images.githubusercontent.com/91706701/220814301-99a32de2-0638-4e14-afcd-167b21a8514f.png">

<!--
Mac OS Screenshots: ctrl + shift + cmd + 3 (entire screen) or 4 (selection of screen), then paste in editor
Mac OS GIFs: Try using Kap
Linux/Windows: Ctrl + Alt + PrintScreen (of a window) or Ctrl + Shift + PrintScreen (selection of screen), then paste in editor
-->
