### PR TITLE
Full width onboarding carousel

### DIFF
--- a/HackIllinois/SwiftUI/UI/HICarouselSwiftUIView.swift
+++ b/HackIllinois/SwiftUI/UI/HICarouselSwiftUIView.swift
@@ -7,7 +7,7 @@
 //  This file is part of the Hackillinois iOS App.
 //  The Hackillinois iOS App is open source software, released under the University of
 //  Illinois/NCSA Open Source License. You should have received a copy of
-//  this license in a file with the distribution.
+//  this license in a file with the distribution. 
 //
 
 import Foundation

--- a/HackIllinois/SwiftUI/UI/HICarouselSwiftUIView.swift
+++ b/HackIllinois/SwiftUI/UI/HICarouselSwiftUIView.swift
@@ -41,13 +41,26 @@ struct HICarouselSwiftUIView: View {
                             .padding(.top, 20)
                     }
                     .tag(index)
+                    .padding(.horizontal, horizontalCarouselPadding)
                 }
             }
             .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
             HITabIndicator(count: carouselData.count, current: $currentIndex)
                 .offset(y: -50)
         }
-        .frame(width: UIDevice.current.userInterfaceIdiom == .pad ? 800: 300)
+        .frame(width: UIScreen.main.bounds.width)
+        .padding(.horizontal, -horizontalCarouselPadding)
+        .ignoresSafeArea()
+    }
+    
+    var horizontalCarouselPadding: CGFloat {
+        let maxWidth = UIScreen.main.bounds.width
+        let carouselWidth = min(800, maxWidth)
+        let padding = maxWidth - carouselWidth
+        return max(
+            CGFloat(padding / 2.0),
+            60
+        )
     }
 }
 


### PR DESCRIPTION
Onboarding carousel frame updated to full width, while maintaining cell sizing across idioms