### PR TITLE
Notify users that there is an app update

### DIFF
--- a/HackIllinois.xcodeproj/project.pbxproj
+++ b/HackIllinois.xcodeproj/project.pbxproj
@@ -1301,7 +1301,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2022.1.2;
+				MARKETING_VERSION = 2024.1.2;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" -Xfrontend -warn-long-expression-type-checking=150";
 				PRODUCT_BUNDLE_IDENTIFIER = org.hackillinois.ios;
@@ -1332,7 +1332,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2022.1.2;
+				MARKETING_VERSION = 2024.1.2;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = org.hackillinois.ios;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/HackIllinois.xcodeproj/project.pbxproj
+++ b/HackIllinois.xcodeproj/project.pbxproj
@@ -1301,7 +1301,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2024.1.2;
+				MARKETING_VERSION = 2024.1.3;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" -Xfrontend -warn-long-expression-type-checking=150";
 				PRODUCT_BUNDLE_IDENTIFIER = org.hackillinois.ios;
@@ -1332,7 +1332,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2024.1.2;
+				MARKETING_VERSION = 2024.1.3;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = org.hackillinois.ios;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/HackIllinois/AppDelegate.swift
+++ b/HackIllinois/AppDelegate.swift
@@ -61,6 +61,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         _ = HILocalNotificationController.shared
         GMSServices.provideAPIKey(String(bytes: obfuscatedApiKey.deobfuscated, encoding: .utf8)!)
         HIApplicationStateController.shared.initalize()
+        // Check the app version and prompt the user to update if needed
+        checkAppVersion()
         return true
     }
 
@@ -123,5 +125,64 @@ extension AppDelegate {
         tableViewAppearance.tableHeaderView = UIView(frame: CGRect(x: 0, y: 0, width: CGFloat.leastNonzeroMagnitude, height: CGFloat.leastNonzeroMagnitude))
         tableViewAppearance.tableFooterView = UIView(frame: CGRect(x: 0, y: 0, width: CGFloat.leastNonzeroMagnitude, height: CGFloat.leastNonzeroMagnitude))
         tableViewAppearance.showsHorizontalScrollIndicator = false
+    }
+}
+
+// MARK: - App Update Check
+extension AppDelegate {
+    // Check version of app against version of API
+    func checkAppVersion() {
+        let apiEndpointURL = URL(string: "https://adonix.hackillinois.org/version/ios")!
+
+        // Create an URLSession task to fetch the API version
+        let task = URLSession.shared.dataTask(with: apiEndpointURL) { data, response, error in
+            if let error = error {
+                NSLog("Error fetching API version: \(error)")
+                return
+            }
+            guard let data = data, let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+                NSLog("Invalid response or status code from API endpoint")
+                return
+            }
+            do {
+                // Parse the JSON response to obtain the API version
+                if let json = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
+                   let apiVersion = json["version"] as? String {
+                    NSLog("API version is \(apiVersion)")
+                    // Get the app's version from Info.plist
+                    if let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String {
+                        if appVersion.compare(apiVersion, options: .numeric) == .orderedAscending {
+                            // App version is less than API version, prompt the user to update
+                            self.showUpdateAlert()
+                        }
+                    }
+                }
+            } catch {
+                NSLog("Error parsing API response: \(error)")
+            }
+        }
+
+        task.resume()
+    }
+
+    func showUpdateAlert() {
+        let alert = UIAlertController(
+            title: "Update Required",
+            message: "A new version of the app is available. Please update to continue.",
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: "Update", style: .default, handler: { _ in
+            // Open the App Store page for app for the user to update
+            if let appURL = URL(string: "https://apps.apple.com/us/app/hackillinois/id1451755268") {
+                UIApplication.shared.open(appURL, options: [:], completionHandler: nil)
+            }
+        }))
+        DispatchQueue.main.async {
+            if let keyWindow = UIApplication.shared.windows.first(where: { $0.isKeyWindow }) {
+                if let rootViewController = keyWindow.rootViewController {
+                    rootViewController.present(alert, animated: true, completion: nil)
+                }
+            }
+        }
     }
 }

--- a/HackIllinois/FlowControllers/HIApplicationStateController.swift
+++ b/HackIllinois/FlowControllers/HIApplicationStateController.swift
@@ -39,7 +39,6 @@ class HIApplicationStateController {
     func initalize() {
         window.makeKeyAndVisible()
         resetPersistentDataIfNeeded()
-        reset2023IfNeeded()
         recoverUserIfPossible()
         recoverProfileIfPossible()
         onboardingViewController.shouldDisplayAnimationOnNextAppearance = user == nil
@@ -51,15 +50,6 @@ class HIApplicationStateController {
 
 // MARK: - API
 extension HIApplicationStateController {
-    func reset2023IfNeeded() {
-        let didReset = UserDefaults.standard.object(forKey: "didReset2023") as? Bool ?? false
-        if !didReset {
-            _ = Keychain.default.purge()
-            HICoreDataController.shared.purge()
-            UserDefaults.standard.set(true, forKey: "didReset2023")
-            logoutUser()
-        }
-    }
     func resetPersistentDataIfNeeded() {
         guard !UserDefaults.standard.bool(forKey: HIConstants.APPLICATION_INSTALLED_KEY) else { return }
         _ = Keychain.default.purge()


### PR DESCRIPTION
## Description

* This feature is used to notify users that there has been an app update.
* Versions are in the format year.version.patch, ex: 2024.1.1.
* This implementation verifies that the iOS app version >= API version.
* If not, then display popup to urge user to update their app.
* Pressing the "Update" button on the alert will direct the user to the HackIllinois App Store page.


<!--
- [ ] Tests
![IMG_7730](https://github.com/HackIllinois/iOS/assets/91706701/77ea6d10-498c-43a0-ac0e-7f93c1bc8e36)

- [ ] More Tests
- [ ] Documentation
-->

## Screenshots

<!--
Mac OS Screenshots: ctrl + shift + cmd + 3 (entire screen) or 4 (selection of screen), then paste in editor
Mac OS GIFs: Try using Kap
Linux/Windows: Ctrl + Alt + PrintScreen (of a window) or Ctrl + Shift + PrintScreen (selection of screen), then paste in editor
-->
![IMG_7730](https://github.com/HackIllinois/iOS/assets/91706701/577d1099-af59-4996-bafb-5ad92b4d9e68)
