### PR TITLE
fixed attendee event endpoint

### DIFF
--- a/HIAPI/Models/Event.swift
+++ b/HIAPI/Models/Event.swift
@@ -66,7 +66,7 @@ public struct StaffEvent: Codable {
 
 public struct Event: Codable {
     internal enum CodingKeys: String, CodingKey {
-        case id
+        case id = "eventId"
         case endTime
         case eventType
         case info = "description"

--- a/HIAPI/Models/Event.swift
+++ b/HIAPI/Models/Event.swift
@@ -35,7 +35,7 @@ public struct StaffEventContainer: Decodable, APIReturnable {
 
 public struct StaffEvent: Codable {
     internal enum CodingKeys: String, CodingKey {
-        case id
+        case id = "eventId"
         case endTime
         case eventType
         case info = "description"
@@ -55,12 +55,12 @@ public struct StaffEvent: Codable {
     public let info: String
     public let locations: [Location]
     public let name: String
-    public let sponsor: String
+    public let sponsor: String?
     public let startTime: Date
-    public let points: Int
+    public let points: Int?
     public let isAsync: Bool
-    public let isPrivate: Bool
-    public let displayOnStaffCheckin: Bool
+    public let isPrivate: Bool?
+    public let displayOnStaffCheckin: Bool?
 }
 
 

--- a/HIAPI/Services/EventService.swift
+++ b/HIAPI/Services/EventService.swift
@@ -24,6 +24,10 @@ public class EventService: BaseService {
         return APIRequest<EventContainer>(service: self, endpoint: "event/", method: .GET)
     }
 
+    public static func getStaffEvents() -> APIRequest<StaffEventContainer> {
+        return APIRequest<StaffEventContainer>(service: self, endpoint: "event/staff/", method: .GET)
+    }
+    
     public static func checkIn(code: String) -> APIRequest<EventCheckInStatus> {
         var body = HTTPBody()
         body["code"] = code

--- a/HackIllinois.xcodeproj/project.pbxproj
+++ b/HackIllinois.xcodeproj/project.pbxproj
@@ -1302,7 +1302,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2024.1.4;
+				MARKETING_VERSION = 2024.1.5;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" -Xfrontend -warn-long-expression-type-checking=150";
 				PRODUCT_BUNDLE_IDENTIFIER = org.hackillinois.ios;
@@ -1333,7 +1333,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2024.1.4;
+				MARKETING_VERSION = 2024.1.5;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = org.hackillinois.ios;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/HackIllinois.xcodeproj/project.pbxproj
+++ b/HackIllinois.xcodeproj/project.pbxproj
@@ -1302,7 +1302,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2024.1.3;
+				MARKETING_VERSION = 2024.1.4;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" -Xfrontend -warn-long-expression-type-checking=150";
 				PRODUCT_BUNDLE_IDENTIFIER = org.hackillinois.ios;
@@ -1333,7 +1333,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2024.1.3;
+				MARKETING_VERSION = 2024.1.4;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = org.hackillinois.ios;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/HackIllinois/DataSources/HITimeDataSource.swift
+++ b/HackIllinois/DataSources/HITimeDataSource.swift
@@ -18,16 +18,16 @@ final class HITimeDataSource {
     static var shared = HITimeDataSource()
 
     public static let defaultTimes = EventTimes(
-        eventStart: Date(timeIntervalSince1970: 1677272400), // Friday, February 25, 2023 6:00:00 PM CST
-        eventEnd: Date(timeIntervalSince1970: 1677445200), // Sunday, February 27, 2023 4:00:00 PM CST
-        hackStart: Date(timeIntervalSince1970: 1677286800), // Friday, February 25, 2023 7:00:00 PM CST
-        hackEnd: Date(timeIntervalSince1970: 1677423600), // Sunday, February 27, 2023 10:00:00 AM CST
-        fridayStart: Date(timeIntervalSince1970: 1677218400), // Friday, February 25, 2023 12:00:00 AM CST
-        fridayEnd: Date(timeIntervalSince1970: 1677304799), // Friday, February 25, 2023 11:59:59 PM CST
-        saturdayStart: Date(timeIntervalSince1970: 1677304800), // Saturday, February 26, 2023 12:00:00 AM CST
-        saturdayEnd: Date(timeIntervalSince1970: 1677391199), // Saturday, February 26, 2023 11:59:59 PM CST
-        sundayStart: Date(timeIntervalSince1970: 1677391200), // Sunday, February 27, 2023 12:00:00 AM CST
-        sundayEnd: Date(timeIntervalSince1970: 1677477599) // Sunday, February 27, 2023 11:59:59 PM CST
+        eventStart: Date(timeIntervalSince1970: 1708732800), // Friday, February 23, 2024 6:00:00 PM CST
+        eventEnd: Date(timeIntervalSince1970: 1708898400), // Sunday, February 25, 2024 4:00:00 PM CST
+        hackStart: Date(timeIntervalSince1970: 1708736400), // Friday, February 23, 2024 7:00:00 PM CST
+        hackEnd: Date(timeIntervalSince1970: 1708876800), // Sunday, February 25, 2024 10:00:00 AM CST
+        fridayStart: Date(timeIntervalSince1970: 1708668000), // Friday, February 23, 2024 12:00:00 AM CST
+        fridayEnd: Date(timeIntervalSince1970: 1708754399), // Friday, February 23, 2024 11:59:59 PM CST
+        saturdayStart: Date(timeIntervalSince1970: 1708754400), // Saturday, February 24, 2024 12:00:00 AM CST
+        saturdayEnd: Date(timeIntervalSince1970: 1708840799), // Saturday, February 24, 2024 11:59:59 PM CST
+        sundayStart: Date(timeIntervalSince1970: 1708840800), // Sunday, February 25, 2024 12:00:00 AM CST
+        sundayEnd: Date(timeIntervalSince1970: 1708927199) // Sunday, February 25, 2024 11:59:59 PM CST
     )
 
     var eventTimes = HITimeDataSource.defaultTimes

--- a/HackIllinois/FlowControllers/HILoginFlowController.swift
+++ b/HackIllinois/FlowControllers/HILoginFlowController.swift
@@ -38,6 +38,7 @@ class HILoginFlowController: UIViewController {
 
     // prevents the login session from going out of scope during presentation
     var loginSession: ASWebAuthenticationSession?
+    var eventsSession: ASWebAuthenticationSession?
 
     // MARK: ViewControllers
     lazy var loginSelectionViewController = HILoginSelectionViewController(delegate: self)
@@ -103,6 +104,7 @@ private extension HILoginFlowController {
             }
             return
         }
+        
         let loginURL = HIAPI.AuthService.oauthURL(provider: user.provider)
         NSLog(loginURL.description)
         loginSession = ASWebAuthenticationSession(url: loginURL, callbackURLScheme: "hackillinois", completionHandler: { [weak self] (url, error) in


### PR DESCRIPTION
## Description

Fixes #544

In the Event Model, I renamed the `id` field to `eventId` to correspond to the update API specifications.