### PR TITLE
Fix attendee login and refactor profile model

### DIFF
--- a/HIAPI/Models/Profile.swift
+++ b/HIAPI/Models/Profile.swift
@@ -25,26 +25,24 @@ public struct ProfileContainer: Decodable, APIReturnable {
 
 public struct Profile: Codable, APIReturnable {
     internal enum CodingKeys: String, CodingKey {
-        case id
-        case firstName
-        case lastName
+        case userId
+        case displayName
         case points
-        case foodWave
-        case discord
+        //case foodWave
+        case discordTag
         case avatarUrl
     }
 
-    public let id: String
-    public let firstName: String
-    public let lastName: String
+    public let userId: String
+    public let displayName: String
     public let points: Int
-    public let foodWave: Int
-    public let discord: String
+    //public let foodWave: Int
+    public let discordTag: String
     public let avatarUrl: String
 }
 
 public struct ProfileFavorites: Codable, APIReturnable {
-    public let id: String
+    public let userId: String
     public let profiles: Set<String>
 }
 
@@ -60,13 +58,13 @@ public struct LeaderboardProfileContainer: Decodable, APIReturnable {
 
 public struct LeaderboardProfile: Codable, APIReturnable {
     internal enum CodingKeys: String, CodingKey {
-        case id
-        case discord
+        case userId
+        case discordTag
         case points
     }
 
-    public let id: String
-    public let discord: String
+    public let userId: String
+    public let discordTag: String
     public let points: Int
 }
 

--- a/HackIllinois/DataSources/HIProfileDataSource.swift
+++ b/HackIllinois/DataSources/HIProfileDataSource.swift
@@ -58,15 +58,15 @@ final class HIProfileDataSource {
                         }
                         coreDataProfilesToUpdate.forEach { (coreDataProfile, apiProfile) in
                             // Update CoreData profile.
-                            coreDataProfile.id = apiProfile.id
-                            coreDataProfile.discord = apiProfile.discord
+                            coreDataProfile.id = apiProfile.userId
+                            coreDataProfile.discord = apiProfile.discordTag
                             coreDataProfile.points = Int32(apiProfile.points)
                         }
                         apiProfilesToInsert.forEach { apiProfile in
                             // Create CoreData profile.
                             let coreDataProfile = LeaderboardProfile(context: context)
-                            coreDataProfile.id = apiProfile.id
-                            coreDataProfile.discord = apiProfile.discord
+                            coreDataProfile.id = apiProfile.userId
+                            coreDataProfile.discord = apiProfile.discordTag
                             coreDataProfile.points = Int32(apiProfile.points)
                         }
 

--- a/HackIllinois/FlowControllers/HILoginFlowController.swift
+++ b/HackIllinois/FlowControllers/HILoginFlowController.swift
@@ -185,7 +185,10 @@ private extension HILoginFlowController {
                 user.roles = apiRolesContainer.roles
                 profile.roles = apiRolesContainer.roles
                 if user.provider == .github && user.roles.contains(.ATTENDEE) {
-                    self?.populateRegistrationData(buildingUser: user, profile: profile, sender: sender)
+                    DispatchQueue.main.async {
+                        NotificationCenter.default.post(name: .loginUser, object: nil, userInfo: ["user": user])
+                    }
+                    self?.populateProfileData(buildingProfile: profile, sender: sender)
                 } else if user.provider == .google {
                     if user.roles.contains(.STAFF) {
                         DispatchQueue.main.async {
@@ -210,7 +213,7 @@ private extension HILoginFlowController {
         .launch()
     }
 
-    private func populateRegistrationData(buildingUser user: HIUser, profile: HIProfile, sender: HIBaseViewController) {
+    /*private func populateRegistrationData(buildingUser user: HIUser, profile: HIProfile, sender: HIBaseViewController) {
         HIAPI.RegistrationService.getAttendee()
         .onCompletion { [weak self] result in
             do {
@@ -229,7 +232,7 @@ private extension HILoginFlowController {
         }
         .authorize(with: user)
         .launch()
-    }
+    }*/
 
     private func populateProfileData(buildingProfile profile: HIProfile, sender: HIBaseViewController) {
         HIAPI.ProfileService.getUserProfile()
@@ -237,11 +240,10 @@ private extension HILoginFlowController {
             do {
                 let (apiProfile, _) = try result.get()
                 var profile = profile
-                profile.id = apiProfile.id
-                profile.firstName = apiProfile.firstName
-                profile.lastName = apiProfile.lastName
+                profile.userId = apiProfile.userId
+                profile.displayName = apiProfile.displayName
                 profile.points = apiProfile.points
-                profile.discord = apiProfile.discord
+                profile.discordTag = apiProfile.discordTag
                 profile.avatarUrl = apiProfile.avatarUrl
                 DispatchQueue.main.async {
                     NotificationCenter.default.post(name: .loginProfile, object: nil, userInfo: ["profile": profile])

--- a/HackIllinois/FlowControllers/HILoginFlowController.swift
+++ b/HackIllinois/FlowControllers/HILoginFlowController.swift
@@ -185,10 +185,10 @@ private extension HILoginFlowController {
                 user.roles = apiRolesContainer.roles
                 profile.roles = apiRolesContainer.roles
                 if user.provider == .github && user.roles.contains(.ATTENDEE) {
+                    self?.populateProfileData(buildingProfile: profile, sender: sender)
                     DispatchQueue.main.async {
                         NotificationCenter.default.post(name: .loginUser, object: nil, userInfo: ["user": user])
                     }
-                    self?.populateProfileData(buildingProfile: profile, sender: sender)
                 } else if user.provider == .google {
                     if user.roles.contains(.STAFF) {
                         DispatchQueue.main.async {
@@ -213,7 +213,7 @@ private extension HILoginFlowController {
         .launch()
     }
 
-    /*private func populateRegistrationData(buildingUser user: HIUser, profile: HIProfile, sender: HIBaseViewController) {
+    private func populateRegistrationData(buildingUser user: HIUser, profile: HIProfile, sender: HIBaseViewController) {
         HIAPI.RegistrationService.getAttendee()
         .onCompletion { [weak self] result in
             do {
@@ -232,7 +232,7 @@ private extension HILoginFlowController {
         }
         .authorize(with: user)
         .launch()
-    }*/
+    }
 
     private func populateProfileData(buildingProfile profile: HIProfile, sender: HIBaseViewController) {
         HIAPI.ProfileService.getUserProfile()

--- a/HackIllinois/Misc/MixTypeComparable.swift
+++ b/HackIllinois/Misc/MixTypeComparable.swift
@@ -121,7 +121,7 @@ extension Project: MixTypeComparable {
 }
 
 extension HIAPI.Profile: MixTypeComparable {
-    var comparable: String { return id }
+    var comparable: String { return userId }
 }
 
 extension Profile: MixTypeComparable {
@@ -129,7 +129,7 @@ extension Profile: MixTypeComparable {
 }
 
 extension HIAPI.LeaderboardProfile: MixTypeComparable {
-    var comparable: String { return id }
+    var comparable: String { return userId }
 }
 
 extension LeaderboardProfile: MixTypeComparable {

--- a/HackIllinois/Models/HIProfile.swift
+++ b/HackIllinois/Models/HIProfile.swift
@@ -21,13 +21,12 @@ struct HIProfile: Codable {
     var attendee: HIAPI.Attendee?
     var token = ""
     var oauthCode = ""
-    var id = ""
-    var firstName = ""
-    var lastName = ""
+    var userId = ""
+    var displayName = ""
     var points = 0
-    var foodWave = 0
+    //var foodWave = 0
     var timezone = ""
-    var discord = ""
+    var discordTag = ""
     var avatarUrl = ""
 
     init(provider: HIAPI.AuthService.OAuthProvider) {

--- a/HackIllinois/ViewControllers/HIProfileCardView.swift
+++ b/HackIllinois/ViewControllers/HIProfileCardView.swift
@@ -14,15 +14,14 @@ import SwiftUI
 import HIAPI
 
 struct HIProfileCardView: View {
-    let firstName: String
-    let lastName: String
+    let displayName: String
     let dietaryRestrictions: [String]
     let points: Int
     let tier: String
     let foodWave: Int
     let background = (\HIAppearance.profileCardBackground).value
     let baseText = (\HIAppearance.profileBaseText).value
-    let id: String
+    let userId: String
     let isIpad = UIDevice.current.userInterfaceIdiom == .pad
     @State var flipped: Bool = false
     @State var ticketRotation = 0.0
@@ -157,10 +156,18 @@ struct HIProfileCardView: View {
     }
 
     func formatName() -> String {
-        if lastName.count + firstName.count > 20 {
-            return firstName + " " + lastName.prefix(1) + "."
+        if displayName.count > 20 {
+            let names = displayName.split(separator: " ")
+            if names.count >= 2 {
+                let firstName = String(names[0])
+                let lastName = String(names[1])
+                let abbreviatedName = firstName + " " + String(lastName.prefix(1)) + "."
+                return abbreviatedName
+            } else {
+                return displayName
+            }
         } else {
-            return firstName + " " + lastName
+            return displayName
         }
     }
 
@@ -268,13 +275,12 @@ struct HIProfileCardView: View {
 
 struct HIProfileCardView_Previews: PreviewProvider {
     static var previews: some View {
-        HIProfileCardView(firstName: "first",
-                          lastName: "last",
+        HIProfileCardView(displayName: "first last",
                           dietaryRestrictions: ["Vegetarian", "Lactose-Intolerant", "None", "no beef"],
                           points: 100,
                           tier: "no tier",
                           foodWave: 1,
-                          id: "https://www.hackillinois.org"
+                          userId: "https://www.hackillinois.org"
         )
     }
 }

--- a/HackIllinois/ViewControllers/HIProfileViewController.swift
+++ b/HackIllinois/ViewControllers/HIProfileViewController.swift
@@ -73,13 +73,13 @@ extension HIProfileViewController {
             view.willRemoveSubview(profileCardController!.view)
             profileCardController?.removeFromParent()
         }
-        profileCardController = UIHostingController(rootView: HIProfileCardView(firstName: profile.firstName,
-                                                                                lastName: profile.lastName,
+        profileCardController = UIHostingController(rootView: HIProfileCardView(firstName: profile.displayName,
+                                                                                lastName: profile.displayName,
                                                                                 dietaryRestrictions: dietaryRestrictions,
                                                                                 points: profile.points,
                                                                                 tier: profileTier,
-                                                                                foodWave: profile.foodWave,
-                                                                                id: profile.id
+                                                                                foodWave: 1,//profile.foodWave,
+                                                                                id: profile.userId
                                                                                ))
 
         addChild(profileCardController!)
@@ -159,11 +159,10 @@ extension HIProfileViewController {
         .onCompletion { [weak self] result in
             do {
                 let (apiProfile, _) = try result.get()
-                self?.profile.id = apiProfile.id
-                self?.profile.firstName = apiProfile.firstName
-                self?.profile.lastName = apiProfile.lastName
+                self?.profile.userId = apiProfile.userId
+                self?.profile.displayName = apiProfile.discordTag
                 self?.profile.points = apiProfile.points
-                self?.profile.foodWave = apiProfile.foodWave
+                //self?.profile.foodWave = apiProfile.foodWave
                 DispatchQueue.main.async {
                     NotificationCenter.default.post(name: .loginProfile, object: nil, userInfo: ["profile": self?.profile])
                     self?.updateProfile()

--- a/HackIllinois/ViewControllers/HIProfileViewController.swift
+++ b/HackIllinois/ViewControllers/HIProfileViewController.swift
@@ -73,13 +73,12 @@ extension HIProfileViewController {
             view.willRemoveSubview(profileCardController!.view)
             profileCardController?.removeFromParent()
         }
-        profileCardController = UIHostingController(rootView: HIProfileCardView(firstName: profile.displayName,
-                                                                                lastName: profile.displayName,
+        profileCardController = UIHostingController(rootView: HIProfileCardView(displayName: profile.displayName,
                                                                                 dietaryRestrictions: dietaryRestrictions,
                                                                                 points: profile.points,
                                                                                 tier: profileTier,
                                                                                 foodWave: 1,//profile.foodWave,
-                                                                                id: profile.userId
+                                                                                userId: profile.userId
                                                                                ))
 
         addChild(profileCardController!)


### PR DESCRIPTION
## Description

* Allows attendees to login by restructuring login flow to not rely on pulling user information from registration data.
* Refactored profile model by changing the following fields: discord to discordTag, id to userId, and first/last name to displayName. 
* Attendees can now login and view their profile.
<img width="323" alt="Screen Shot 2023-11-23 at 2 14 37 PM" src="https://github.com/HackIllinois/iOS/assets/91706701/cf522633-60cb-400a-a0bd-c37c854a0179">
