### PR TITLE
Quick fix: Default alert color to white 

### DIFF
--- a/HackIllinois.xcodeproj/project.pbxproj
+++ b/HackIllinois.xcodeproj/project.pbxproj
@@ -1375,7 +1375,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2024.2.2;
+				MARKETING_VERSION = 2024.2.3;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" -Xfrontend -warn-long-expression-type-checking=150";
 				PRODUCT_BUNDLE_IDENTIFIER = org.hackillinois.ios;
@@ -1407,7 +1407,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2024.2.2;
+				MARKETING_VERSION = 2024.2.3;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = org.hackillinois.ios;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/HackIllinois/ViewControllers/HIScanAttendanceViewController.swift
+++ b/HackIllinois/ViewControllers/HIScanAttendanceViewController.swift
@@ -203,6 +203,7 @@ extension HIScanAttendanceViewController: AVCaptureMetadataOutputObjectsDelegate
             alertMessage = "Something isn't quite right."
         }
         let alert = UIAlertController(title: alertTitle, message: alertMessage, preferredStyle: .alert)
+        alert.view.backgroundColor = UIColor.white
         if alertTitle == "Success!" {
             alert.addAction(
                 UIAlertAction(title: "OK", style: .default, handler: { _ in

--- a/HackIllinois/ViewControllers/HIScanAttendanceViewController.swift
+++ b/HackIllinois/ViewControllers/HIScanAttendanceViewController.swift
@@ -203,7 +203,6 @@ extension HIScanAttendanceViewController: AVCaptureMetadataOutputObjectsDelegate
             alertMessage = "Something isn't quite right."
         }
         let alert = UIAlertController(title: alertTitle, message: alertMessage, preferredStyle: .alert)
-        alert.view.backgroundColor = UIColor.white
         if alertTitle == "Success!" {
             alert.addAction(
                 UIAlertAction(title: "OK", style: .default, handler: { _ in

--- a/HackIllinois/ViewControllers/HIScanMentorViewController.swift
+++ b/HackIllinois/ViewControllers/HIScanMentorViewController.swift
@@ -210,16 +210,19 @@ extension HIScanMentorViewController: AVCaptureMetadataOutputObjectsDelegate {
             error = false
         default:
             alertTitle = "\n\nError!"
-            alertMessage = "\nSomething isn't quite right."
+            alertMessage = "\nThis QR code is invalid or you have already checked in to this mentor's office hours."
             self.respondingToQRCodeFound = true
         }
         // Create custom alert for attendee check in functionality
         let alert = UIAlertController(title: alertTitle, message: alertMessage, preferredStyle: .alert)
-        alert.view.backgroundColor = UIColor.white
+        
         let titleFont = UIFont(name: "MontserratRoman-Bold", size: 22)
         let messageFont = UIFont(name: "MontserratRoman-Medium", size: 16)
-        let titleColor = #colorLiteral(red: 0.337254902, green: 0.1411764706, blue: 0.06666666667, alpha: 1)
-        let messageColor = #colorLiteral(red: 0.337254902, green: 0.1411764706, blue: 0.06666666667, alpha: 1)
+        
+        let userInterfaceStyle = traitCollection.userInterfaceStyle
+        let titleColor: UIColor = (userInterfaceStyle == .dark) ? UIColor.white : #colorLiteral(red: 0.337254902, green: 0.1411764706, blue: 0.06666666667, alpha: 1)
+        let messageColor: UIColor = (userInterfaceStyle == .dark) ? UIColor.white : #colorLiteral(red: 0.337254902, green: 0.1411764706, blue: 0.06666666667, alpha: 1)
+        
         let attributedTitle = NSAttributedString(string: alertTitle, attributes: [NSAttributedString.Key.font: titleFont as Any, NSAttributedString.Key.foregroundColor: titleColor])
         let attributedMessage = NSAttributedString(string: alertMessage, attributes: [NSAttributedString.Key.font: messageFont as Any, NSAttributedString.Key.foregroundColor: messageColor])
         alert.setValue(attributedTitle, forKey: "attributedTitle")

--- a/HackIllinois/ViewControllers/HIScanMentorViewController.swift
+++ b/HackIllinois/ViewControllers/HIScanMentorViewController.swift
@@ -215,6 +215,7 @@ extension HIScanMentorViewController: AVCaptureMetadataOutputObjectsDelegate {
         }
         // Create custom alert for attendee check in functionality
         let alert = UIAlertController(title: alertTitle, message: alertMessage, preferredStyle: .alert)
+        alert.view.backgroundColor = UIColor.white
         let titleFont = UIFont(name: "MontserratRoman-Bold", size: 22)
         let messageFont = UIFont(name: "MontserratRoman-Medium", size: 16)
         let titleColor = #colorLiteral(red: 0.337254902, green: 0.1411764706, blue: 0.06666666667, alpha: 1)

--- a/HackIllinois/ViewControllers/HIScanPointsShopViewController.swift
+++ b/HackIllinois/ViewControllers/HIScanPointsShopViewController.swift
@@ -222,15 +222,18 @@ extension HIScanPointsShopViewController: AVCaptureMetadataOutputObjectsDelegate
             self.respondingToQRCodeFound = true
         default:
             alertTitle = "\n\nError!"
-            alertMessage = "\nSomething isn't quite right."
+            alertMessage = "\nSomething isn't quite right. Double check your coins amount and make sure you have the correct QR code."
             self.respondingToQRCodeFound = true
         }
         // Create custom alert for points shop
         let alert = UIAlertController(title: alertTitle, message: alertMessage, preferredStyle: .alert)
+        
         let titleFont = UIFont(name: "MontserratRoman-Bold", size: 22)
         let messageFont = UIFont(name: "MontserratRoman-Medium", size: 16)
-        let titleColor = #colorLiteral(red: 0.337254902, green: 0.1411764706, blue: 0.06666666667, alpha: 1)
-        let messageColor = #colorLiteral(red: 0.337254902, green: 0.1411764706, blue: 0.06666666667, alpha: 1)
+        
+        let userInterfaceStyle = traitCollection.userInterfaceStyle
+        let titleColor: UIColor = (userInterfaceStyle == .dark) ? UIColor.white : #colorLiteral(red: 0.337254902, green: 0.1411764706, blue: 0.06666666667, alpha: 1)
+        let messageColor: UIColor = (userInterfaceStyle == .dark) ? UIColor.white : #colorLiteral(red: 0.337254902, green: 0.1411764706, blue: 0.06666666667, alpha: 1)
         let attributedTitle = NSAttributedString(string: alertTitle, attributes: [NSAttributedString.Key.font: titleFont as Any, NSAttributedString.Key.foregroundColor: titleColor])
         let attributedMessage = NSAttributedString(string: alertMessage, attributes: [NSAttributedString.Key.font: messageFont as Any, NSAttributedString.Key.foregroundColor: messageColor])
         alert.setValue(attributedTitle, forKey: "attributedTitle")

--- a/HackIllinois/ViewControllers/HIScanQRCodeViewController.swift
+++ b/HackIllinois/ViewControllers/HIScanQRCodeViewController.swift
@@ -271,16 +271,19 @@ extension HIScanQRCodeViewController: AVCaptureMetadataOutputObjectsDelegate {
             self.respondingToQRCodeFound = true
         default:
             alertTitle = "\n\nError!"
-            alertMessage = "\nSomething isn't quite right."
+            alertMessage = "\nYou may have the incorrect QR code or you have already checked into this event."
             self.respondingToQRCodeFound = true
         }
         // Create custom alert for attendee check in functionality
         let alert = UIAlertController(title: alertTitle, message: alertMessage, preferredStyle: .alert)
-        alert.view.backgroundColor = UIColor.white
+        
         let titleFont = UIFont(name: "MontserratRoman-Bold", size: 22)
         let messageFont = UIFont(name: "MontserratRoman-Medium", size: 16)
-        let titleColor = #colorLiteral(red: 0.337254902, green: 0.1411764706, blue: 0.06666666667, alpha: 1)
-        let messageColor = #colorLiteral(red: 0.337254902, green: 0.1411764706, blue: 0.06666666667, alpha: 1)
+        
+        let userInterfaceStyle = traitCollection.userInterfaceStyle
+        let titleColor: UIColor = (userInterfaceStyle == .dark) ? UIColor.white : #colorLiteral(red: 0.337254902, green: 0.1411764706, blue: 0.06666666667, alpha: 1)
+        let messageColor: UIColor = (userInterfaceStyle == .dark) ? UIColor.white : #colorLiteral(red: 0.337254902, green: 0.1411764706, blue: 0.06666666667, alpha: 1)
+        
         let attributedTitle = NSAttributedString(string: alertTitle, attributes: [NSAttributedString.Key.font: titleFont as Any, NSAttributedString.Key.foregroundColor: titleColor])
         let attributedMessage = NSAttributedString(string: alertMessage, attributes: [NSAttributedString.Key.font: messageFont as Any, NSAttributedString.Key.foregroundColor: messageColor])
         alert.setValue(attributedTitle, forKey: "attributedTitle")
@@ -331,15 +334,19 @@ extension HIScanQRCodeViewController: AVCaptureMetadataOutputObjectsDelegate {
             self.respondingToQRCodeFound = true
         case "The operation couldn’t be completed. (APIManager.APIRequestError error 0.)":
             alertTitle = "Error!"
-            alertMessage = "Your QR code is either invalid/expired or you have already checked into this event."
+            alertMessage = "The QR code is either invalid/expired or the user has already checked into this event."
+            self.respondingToQRCodeFound = true
+        case "Incorrect type of QR code":
+            alertTitle = "Error!"
+            alertMessage = "This is not a valid user QR code."
             self.respondingToQRCodeFound = true
         default:
             alertTitle = "Error!"
-            alertMessage = "Something isn't quite right."
+            alertMessage = "The QR code is either invalid/expired or the user has already checked into this event."
             self.respondingToQRCodeFound = true
         }
         let alert = UIAlertController(title: alertTitle, message: alertMessage, preferredStyle: .alert)
-        alert.view.backgroundColor = UIColor.white
+        
         if alertTitle == "Success!" {
             alert.addAction(
                 UIAlertAction(title: "OK", style: .default, handler: { _ in
@@ -425,8 +432,10 @@ extension HIScanQRCodeViewController: AVCaptureMetadataOutputObjectsDelegate {
                         }
                         .authorize(with: HIApplicationStateController.shared.user)
                         .launch()
-                    }
+                } else {
+                    self.handleStaffCheckInAlert(status: "Incorrect type of QR code")
                 }
+            }
         } else {
             respondingToQRCodeFound = false
             HIAPI.UserService.userScanEvent(userToken: user.token, eventID: code)

--- a/HackIllinois/ViewControllers/HIScanQRCodeViewController.swift
+++ b/HackIllinois/ViewControllers/HIScanQRCodeViewController.swift
@@ -276,6 +276,7 @@ extension HIScanQRCodeViewController: AVCaptureMetadataOutputObjectsDelegate {
         }
         // Create custom alert for attendee check in functionality
         let alert = UIAlertController(title: alertTitle, message: alertMessage, preferredStyle: .alert)
+        alert.view.backgroundColor = UIColor.white
         let titleFont = UIFont(name: "MontserratRoman-Bold", size: 22)
         let messageFont = UIFont(name: "MontserratRoman-Medium", size: 16)
         let titleColor = #colorLiteral(red: 0.337254902, green: 0.1411764706, blue: 0.06666666667, alpha: 1)
@@ -338,6 +339,7 @@ extension HIScanQRCodeViewController: AVCaptureMetadataOutputObjectsDelegate {
             self.respondingToQRCodeFound = true
         }
         let alert = UIAlertController(title: alertTitle, message: alertMessage, preferredStyle: .alert)
+        alert.view.backgroundColor = UIColor.white
         if alertTitle == "Success!" {
             alert.addAction(
                 UIAlertAction(title: "OK", style: .default, handler: { _ in


### PR DESCRIPTION
## Description

* Default alert background color to white, even on dark mode devices.